### PR TITLE
Expect para_id on load_spec for parachain

### DIFF
--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -65,7 +65,7 @@ impl SubstrateCli for Cli {
 	}
 
 	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
-		load_spec(id, self.run.parachain_id.unwrap_or(200).into())
+		load_spec(id, self.run.parachain_id.expect("Missing para_id").into())
 	}
 
 	fn native_runtime_version(_: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {


### PR DESCRIPTION
Thinking on parachain nodes that can be built from this template, maybe is better explicitly defining the `para_id` for the parachain than having a fallback.

Should we add changes on the README or any documentation ?