### PR TITLE
remove ss58Format on chain_spec

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -66,7 +66,6 @@ pub fn development_config() -> ChainSpec {
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "UNIT".into());
 	properties.insert("tokenDecimals".into(), 12.into());
-	properties.insert("ss58Format".into(), 42.into());
 
 	ChainSpec::from_genesis(
 		// Name


### PR DESCRIPTION
Ss58 format under chain Spec does not work, it is a redundant parameter.
Ss58-prefix Is affected only by the SS58-prefix configuration under runtime.
https://github.com/substrate-developer-hub/substrate-parachain-template/blob/main/runtime/src/lib.rs#L249