### PR TITLE
Add missing features

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -87,15 +87,19 @@ std = [
 	"cumulus-pallet-aura-ext/std",
 	"cumulus-pallet-dmp-queue/std",
 	"cumulus-pallet-parachain-system/std",
+	"cumulus-pallet-session-benchmarking/std",
 	"cumulus-pallet-xcm/std",
 	"cumulus-pallet-xcmp-queue/std",
 	"cumulus-primitives-core/std",
 	"cumulus-primitives-timestamp/std",
 	"cumulus-primitives-utility/std",
+	"frame-benchmarking/std",
 	"frame-executive/std",
 	"frame-support/std",
 	"frame-system-rpc-runtime-api/std",
 	"frame-system/std",
+	"frame-system-benchmarking/std",
+	"frame-try-runtime/std",
 	"pallet-aura/std",
 	"pallet-authorship/std",
 	"pallet-balances/std",
@@ -129,6 +133,9 @@ std = [
 
 runtime-benchmarks = [
 	"hex-literal",
+	"cumulus-pallet-parachain-system/runtime-benchmarks",
+	"cumulus-pallet-session-benchmarking/runtime-benchmarks",
+	"cumulus-pallet-xcmp-queue/runtime-benchmarks",
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system-benchmarking/runtime-benchmarks",
@@ -138,10 +145,11 @@ runtime-benchmarks = [
 	"pallet-template/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 	"pallet-xcm/runtime-benchmarks",
+	"polkadot-parachain/runtime-benchmarks",
+	"polkadot-runtime-common/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
-	"cumulus-pallet-session-benchmarking/runtime-benchmarks",
-	"cumulus-pallet-xcmp-queue/runtime-benchmarks",
+	"xcm-executor/runtime-benchmarks",
 ]
 
 try-runtime = [
@@ -151,6 +159,7 @@ try-runtime = [
 	"cumulus-pallet-xcm/try-runtime",
 	"cumulus-pallet-xcmp-queue/try-runtime",
 	"frame-executive/try-runtime",
+	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"frame-try-runtime",
 	"pallet-aura/try-runtime",
@@ -163,5 +172,6 @@ try-runtime = [
 	"pallet-timestamp/try-runtime",
 	"pallet-transaction-payment/try-runtime",
 	"pallet-xcm/try-runtime",
+	"polkadot-runtime-common/try-runtime",
 	"parachain-info/try-runtime",
 ]


### PR DESCRIPTION
```
subalfred check features runtime
checking: runtime/Cargo.toml
incomplete `runtime-benchmarks` of `cumulus-pallet-parachain-system`
incomplete `runtime-benchmarks` of `polkadot-parachain`
incomplete `runtime-benchmarks` of `polkadot-runtime-common`
incomplete `runtime-benchmarks` of `xcm-executor`
incomplete `std` of `cumulus-pallet-session-benchmarking`
incomplete `std` of `frame-benchmarking`
incomplete `std` of `frame-system-benchmarking`
incomplete `std` of `frame-try-runtime`
incomplete `try-runtime` of `frame-support`
incomplete `try-runtime` of `polkadot-runtime-common`
```