### PR TITLE
Release pipeline for multiarch binaries and an image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,6 @@ jobs:
           rustup update stable --no-self-update
           rustup target add wasm32-unknown-unknown
 
-      # Rust cache
-      - uses: Swatinem/rust-cache@v2
-
       - name: Install linux dependencies
         if: (matrix.os == '' || startsWith(matrix.os, 'ubuntu'))
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,158 @@
+# This is an example GitHub action that will build and publish the binaries and a Docker image
+# You need to add the following secrets to your GitHub Repository or Organization to make this work
+# - DOCKERHUB_USERNAME: The username of the DockerHub account. E.g. parity
+# - DOCKERHUB_TOKEN: Access token for DockerHub, see https://docs.docker.com/docker-hub/access-tokens/.
+# The following is set up as an environment variable below
+# - DOCKER_REPO: The unique name of the DockerHub repository. E.g. parity/polkadot
+
+name: Release
+
+permissions:
+  contents: read
+
+# Controls when the action will run.
+on:
+  push:
+    # Triggers the workflow on tag push events
+    tags:
+      - v[0-9]+.*
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+  CARGO_NET_RETRY: 10
+  RUSTFLAGS: -D warnings
+  RUSTUP_MAX_RETRIES: 10
+  CARGO_TERM_COLOR: always
+  # Set an environment variable (that can be overriden) for the Docker Repo
+  DOCKER_REPO: tripleight/parachain-template
+
+defaults:
+  run:
+    shell: bash
+
+
+jobs:
+  create-release:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          title: $version
+          branch: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-assets:
+    name: ${{ matrix.target }}
+    needs:
+      - create-release
+    strategy:
+      matrix:
+        # The list of architechture and OS to build for
+        # You can add or remove targets here if you want
+        #
+        # When updating this list, remember to update the target list in tests too
+        include:
+          # - target: aarch64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-gnu
+          - target: aarch64-apple-darwin
+            os: macos-11
+          - target: x86_64-apple-darwin
+            os: macos-11
+          # - target: universal-apple-darwin
+          #   os: macos-11
+
+    # The type of runner that the job will run on
+    # Runs on Ubuntu if other os is not specified above
+    runs-on: ${{ matrix.os || 'ubuntu-22.04' }}
+    timeout-minutes: 90
+    permissions:
+      contents: write
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        run: |
+          rustup update stable --no-self-update
+          rustup target add wasm32-unknown-unknown
+
+      # Rust cache
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install linux dependencies
+        if: (matrix.os == '' || startsWith(matrix.os, 'ubuntu'))
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Install mac dependencies
+        if: startsWith(matrix.os, 'macos')
+        run: brew install protobuf
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        if: (matrix.os == '' || startsWith(matrix.os, 'ubuntu'))
+        with:
+          target: ${{ matrix.target }}
+
+      # Build and upload the binary to the new release
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: parachain-template
+          target: ${{ matrix.target }}
+          tar: all
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload x86_64 linux binary to workflow
+        if: (matrix.target == 'x86_64-unknown-linux-gnu')
+        uses: actions/upload-artifact@v3
+        with:
+          name: parachain-template
+          path: ${{ github.workspace }}/target/x86_64-unknown-linux-gnu/release/parachain-template
+
+  build-image:
+    # The type of runner that the job will run on
+    needs:
+      - upload-assets
+    runs-on: ubuntu-22.04
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Login to Docker hub using the credentials stored in the repository secrets
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      # Download the binary from the previous job
+      - name: Download x86_64 linux binary
+        uses: actions/download-artifact@v3
+        with:
+          name: parachain-template
+          path: ${{ github.workspace }}
+
+      # Build and push 2 images, One with the version tag and the other with latest tag
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Containerfile
+          push: true
+          build-args: |
+            DOCKER_REPO=${{ env.DOCKER_REPO }}
+          tags: |
+            ${{ env.DOCKER_REPO }}:${{ github.ref_name }}
+            ${{ env.DOCKER_REPO }}:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
       # Build and upload the binary to the new release
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
-          bin: parachain-template
+          bin: parachain-template-node
           target: ${{ matrix.target }}
           tar: all
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -116,8 +116,8 @@ jobs:
         if: (matrix.target == 'x86_64-unknown-linux-gnu')
         uses: actions/upload-artifact@v3
         with:
-          name: parachain-template
-          path: ${{ github.workspace }}/target/x86_64-unknown-linux-gnu/release/parachain-template
+          name: parachain-template-node
+          path: ${{ github.workspace }}/target/x86_64-unknown-linux-gnu/release/parachain-template-node
 
   build-image:
     # The type of runner that the job will run on
@@ -141,7 +141,7 @@ jobs:
       - name: Download x86_64 linux binary
         uses: actions/download-artifact@v3
         with:
-          name: parachain-template
+          name: parachain-template-node
           path: ${{ github.workspace }}
 
       # Build and push 2 images, One with the version tag and the other with latest tag

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -1,42 +1,38 @@
 name: Test Code
 
+# Controls when the action will run.
 on:
+  # Triggers the workflow on push or pull request events but only for the master branch
   pull_request:
     branches:
     - main
   push:
     branches:
     - main
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   test-code:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
+    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout Code
-      uses: actions/checkout@v2
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v1
+      uses: actions/checkout@v3
 
-      # Steps taken from https://github.com/actions/cache/blob/master/examples.md#rust---cargo
-    - name: Cache cargo registry
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install linux dependencies
+      run: sudo apt-get install -y clang libssl-dev llvm libudev-dev protobuf-compiler
 
-    - name: Install toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        components: rustfmt, clippy
-        target: wasm32-unknown-unknown
-        override: true
-        default: true
+    - name: Install Rust
+      run: |
+        rustup update stable --no-self-update
+        rustup target add wasm32-unknown-unknown
+
+    # Rust cache
+    - uses: Swatinem/rust-cache@v2
 
     # Enable this for clippy linting.
     # - name: Check and Lint Code

--- a/Containerfile
+++ b/Containerfile
@@ -7,19 +7,21 @@ ENV RUST_BACKTRACE 1
 RUN apt-get update && \
 	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 		ca-certificates && \
-  useradd -m -u 1000 -U -s /bin/sh -d /parachain-template parachain-template && \
 # apt cleanup
 	apt-get autoremove -y && \
 	apt-get clean && \
-	rm -rf /var/lib/apt/lists/* && \
-	mkdir -p /data /parachain-template/.local/share && \
-	chown -R parachain-template:parachain-template /data && \
-	ln -s /data /parachain-template/.local/share/parachain-template
+	find /var/lib/apt/lists/ -type f -not -name lock -delete; \
+# add user and link ~/.local/share/polkadot to /data
+	useradd -m -u 1000 -U -s /bin/sh -d /polkadot polkadot && \
+	mkdir -p /data /polkadot/.local/share && \
+	chown -R polkadot:polkadot /data && \
+	ln -s /data /polkadot/.local/share/parachain-template-node && \
+	mkdir -p /specs
 
-USER parachain-template
+USER polkadot
 
 # copy the compiled binary to the container
-COPY --chown=parachain-template:parachain-template --chmod=774 parachain-template-node /usr/bin/parachain-template-node
+COPY --chown=polkadot:polkadot --chmod=774 parachain-template-node /usr/bin/parachain-template-node
 
 # check if executable works in this container
 RUN /usr/bin/parachain-template-node --version

--- a/Containerfile
+++ b/Containerfile
@@ -19,14 +19,12 @@ RUN apt-get update && \
 USER parachain-template
 
 # copy the compiled binary to the container
-COPY --chown=parachain-template:parachain-template --chmod=774 parachain-template /usr/bin/parachain-template
+COPY --chown=parachain-template:parachain-template --chmod=774 parachain-template-node /usr/bin/parachain-template-node
 
 # check if executable works in this container
-RUN /usr/bin/parachain-template --version
+RUN /usr/bin/parachain-template-node --version
 
 # ws_port
-EXPOSE 9930 9333 9944 30333 30334
+EXPOSE 9333 9944 30333 30334
 
-VOLUME ["/parachain-template"]
-
-ENTRYPOINT ["/usr/bin/parachain-template"]
+CMD ["/usr/bin/parachain-template-node"]

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,32 @@
+FROM docker.io/library/ubuntu:22.04
+
+# show backtraces
+ENV RUST_BACKTRACE 1
+
+# install tools and dependencies
+RUN apt-get update && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		ca-certificates && \
+  useradd -m -u 1000 -U -s /bin/sh -d /parachain-template parachain-template && \
+# apt cleanup
+	apt-get autoremove -y && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* && \
+	mkdir -p /data /parachain-template/.local/share && \
+	chown -R parachain-template:parachain-template /data && \
+	ln -s /data /parachain-template/.local/share/parachain-template
+
+USER parachain-template
+
+# copy the compiled binary to the container
+COPY --chown=parachain-template:parachain-template --chmod=774 parachain-template /usr/bin/parachain-template
+
+# check if executable works in this container
+RUN /usr/bin/parachain-template --version
+
+# ws_port
+EXPOSE 9930 9333 9944 30333 30334
+
+VOLUME ["/parachain-template"]
+
+ENTRYPOINT ["/usr/bin/parachain-template"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,5 @@ at each release branch using the
 👉 Learn more about parachains [here](https://wiki.polkadot.network/docs/learn-parachains), and
 parathreads [here](https://wiki.polkadot.network/docs/learn-parathreads).
 
-
 🧙 Learn about how to use this template and run your own parachain testnet for it in the
 [Devhub Cumulus Tutorial](https://docs.substrate.io/tutorials/v3/cumulus/start-relay/).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can modify the compilation targets depending on your needs.
 
 Allow GitHub actions in your forked repository to build the binary for you.
 
-Push a tag. I.e. `v0.1.1`. The supported tag format is `v?MAJOR.MINOR.PATCH(-PRERELEASE)?(+BUILD_METADATA)?`. (leading "v", pre-release version, and build metadata are optional.) The optional prefix is also supported. This is based on [Semantic Versioning](https://semver.org/).
+Push a tag. For example, `v0.1.1`. Based on [Semantic Versioning](https://semver.org/), the supported tag format is `v?MAJOR.MINOR.PATCH(-PRERELEASE)?(+BUILD_METADATA)?` (the leading "v", pre-release version, and build metadata are optional and the optional prefix is also supported).
 
 After the pipeline is finished, you can download the binary from the releases page.
 

--- a/README.md
+++ b/README.md
@@ -19,3 +19,27 @@ parathreads [here](https://wiki.polkadot.network/docs/learn-parathreads).
 
 🧙 Learn about how to use this template and run your own parachain testnet for it in the
 [Devhub Cumulus Tutorial](https://docs.substrate.io/tutorials/v3/cumulus/start-relay/).
+
+## CI
+
+### Binary
+
+Check the [CI release workflow](./.github/workflows/release.yml) to see how the binary is built on CI.
+Remove or add the compilation targets.
+
+Allow GitHub actions in your forked repository to build the binary for you.
+
+Push a tag. I.e. `v0.1.1`. The supported tag format is `v?MAJOR.MINOR.PATCH(-PRERELEASE)?(+BUILD_METADATA)?`. (leading "v", pre-release version, and build metadata are optional.) The optional prefix is also supported. This is based on [Semantic Versioning](https://semver.org/).
+
+After the pipeline is finished, you can download the binary from the releases page.
+
+### Container
+
+Check the [CI release workflow](./.github/workflows/release.yml) to see how the Docker image is built on CI.
+
+Add your `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets to your forked repository or organization settings.
+Change the `DOCKER_REPO` variable in the workflow to `[your DockerHub registry name]/[image name]`.
+
+Push a tag.
+
+After the image is built and pushed, you can pull it with `docker pull <DOCKER_REPO>:<tag>`.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ After the pipeline is finished, you can download the binary from the releases pa
 
 Check the [CI release workflow](./.github/workflows/release.yml) to see how the Docker image is built on CI.
 
-Add your `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets to your forked repository or organization settings.
+Add your `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets or other organization settings to your forked repository.
 Change the `DOCKER_REPO` variable in the workflow to `[your DockerHub registry name]/[image name]`.
 
 Push a tag.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ parathreads [here](https://wiki.polkadot.network/docs/learn-parathreads).
 ### Binary
 
 Check the [CI release workflow](./.github/workflows/release.yml) to see how the binary is built on CI.
-Remove or add the compilation targets.
+You can modify the compilation targets depending on your needs.
 
 Allow GitHub actions in your forked repository to build the binary for you.
 


### PR DESCRIPTION
More out-of-the box features for those who fork from this template

- fixed check pipeline
- CI pipeline
  -  builds binaries for multiple architectures
  - creates a release and publishes binaries
  -  builds and publishes an image
- docs
- dependabot for CI and cargo